### PR TITLE
Add descriptive CMake output (and update .gitignore) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@ bin/
 build/
 out/
 CMakeSettings.json
+CMakeCache.txt
+CPackConfig.cmake
+CPackSourceConfig.cmake
+CMakeFiles
+cmake_install.cmake
+compile_commands.json
+_deps
+Makefile
+my_raylib_game


### PR DESCRIPTION
This PR tweaks the CMake build so that instead of CMake seeming to hang on the terminal (when in actually fact it is downloading Raylib) there is terminal output indicating what CMake is doing and its progress.

Additionally the PR adds some extra files to .gitignore so that build files don't accidentally get committed to git.

This PR has also been made upstream to https://github.com/SasLuca/raylib-cmake-template/